### PR TITLE
enhance: Refactor dataset storage option to use netip module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,9 +11,11 @@ require (
 	github.com/oschwald/geoip2-golang v1.9.0
 	github.com/prometheus/client_golang v1.19.0
 	github.com/sirupsen/logrus v1.9.3
+	github.com/stretchr/testify v1.9.0
 	golang.org/x/sync v0.7.0
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 	gopkg.in/yaml.v2 v2.4.0
+	gotest.tools/v3 v3.5.0
 )
 
 require (
@@ -22,6 +24,7 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fatih/color v1.15.0 // indirect
 	github.com/go-openapi/analysis v0.21.4 // indirect
 	github.com/go-openapi/errors v0.20.4 // indirect
@@ -34,6 +37,7 @@ require (
 	github.com/go-openapi/validate v0.22.1 // indirect
 	github.com/goccy/go-yaml v1.11.2 // indirect
 	github.com/golang-jwt/jwt/v4 v4.5.0 // indirect
+	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
@@ -42,6 +46,7 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
 	github.com/oschwald/maxminddb-golang v1.12.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_model v0.5.0 // indirect
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	golang.org/x/sync v0.7.0
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 	gopkg.in/yaml.v2 v2.4.0
-	gotest.tools/v3 v3.5.0
 )
 
 require (
@@ -37,7 +36,6 @@ require (
 	github.com/go-openapi/validate v0.22.1 // indirect
 	github.com/goccy/go-yaml v1.11.2 // indirect
 	github.com/golang-jwt/jwt/v4 v4.5.0 // indirect
-	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -190,8 +190,8 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
-github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=
 github.com/xdg-go/scram v1.0.2/go.mod h1:1WAq6h33pAW+iRreB34OORO2Nf7qel3VV3fjBj+hCSs=
@@ -295,3 +295,5 @@ gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gotest.tools/v3 v3.5.0 h1:Ljk6PdHdOhAb5aDMWXjDLMMhph+BpztA4v1QdqEW2eY=
+gotest.tools/v3 v3.5.0/go.mod h1:isy3WKz7GK6uNw/sbHzfKBLvlvXwUyV06n6brMxxopU=

--- a/go.sum
+++ b/go.sum
@@ -295,5 +295,3 @@ gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gotest.tools/v3 v3.5.0 h1:Ljk6PdHdOhAb5aDMWXjDLMMhph+BpztA4v1QdqEW2eY=
-gotest.tools/v3 v3.5.0/go.mod h1:isy3WKz7GK6uNw/sbHzfKBLvlvXwUyV06n6brMxxopU=

--- a/internal/api/root.go
+++ b/internal/api/root.go
@@ -296,13 +296,12 @@ func NewApi(ctx context.Context, WorkerManager *worker.Manager, HostManager *hos
 				}
 
 				log.Infof("Checking IP %s", args[0])
-				val := net.ParseIP(args[0])
 
-				if val == nil {
-					return nil, fmt.Errorf("invalid IP")
+				r, err := a.Dataset.CheckIP(args[0])
+
+				if err != nil {
+					return nil, err
 				}
-
-				r := a.Dataset.CheckIP(&val)
 
 				if permission == apiPermission.WorkerPermission {
 					return r, nil

--- a/pkg/dataset/root.go
+++ b/pkg/dataset/root.go
@@ -17,7 +17,6 @@ type DataSet struct {
 }
 
 func New() *DataSet {
-	log.Info("Using new datasets")
 	PrefixSet := PrefixSet{}
 	PrefixSet.Init("CIDRSet")
 	CNSet := CNSet{}

--- a/pkg/dataset/root_test.go
+++ b/pkg/dataset/root_test.go
@@ -127,25 +127,25 @@ func TestDataSet(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if len(tt.toAdd) > 0 {
 				dataSet.Add(tt.toAdd)
-				if tt.toCheck == nil {
-					t.Fatalf("toCheck is nil")
-				}
-				var r remediation.Remediation
-				var err error
-				switch tt.toCheck.Scope {
-				case "IP":
-					r, err = dataSet.CheckIP(tt.toCheck.Value)
-				case "Country":
-					r = dataSet.CheckCN(tt.toCheck.Value)
-				default:
-					t.Fatalf("unknown scope %s", tt.toCheck.Scope)
-				}
-				require.NoError(t, err)
-				assert.Equal(t, r, tt.toCheck.Type)
 			}
 			if len(tt.toDelete) > 0 {
 				dataSet.Remove(tt.toDelete)
 			}
+			if tt.toCheck == nil {
+				t.Fatalf("toCheck is nil")
+			}
+			var r remediation.Remediation
+			var err error
+			switch tt.toCheck.Scope {
+			case "IP":
+				r, err = dataSet.CheckIP(tt.toCheck.Value)
+			case "Country":
+				r = dataSet.CheckCN(tt.toCheck.Value)
+			default:
+				t.Fatalf("unknown scope %s", tt.toCheck.Scope)
+			}
+			require.NoError(t, err)
+			assert.Equal(t, r, tt.toCheck.Type)
 		})
 	}
 

--- a/pkg/dataset/root_test.go
+++ b/pkg/dataset/root_test.go
@@ -1,0 +1,152 @@
+package dataset
+
+import (
+	"testing"
+
+	"github.com/crowdsecurity/crowdsec-spoa/internal/remediation"
+	"github.com/crowdsecurity/crowdsec/pkg/models"
+	"github.com/crowdsecurity/go-cs-lib/ptr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// toCheck is a struct to check the result of the addition or deletion of a decision
+type toCheck struct {
+	Value string // IP, Country
+	Scope string // IP, Country
+	Type  remediation.Remediation
+}
+
+func TestDataSet(t *testing.T) {
+	dataSet := New()
+	tests := []struct {
+		name     string
+		toAdd    models.GetDecisionsResponse
+		toDelete models.GetDecisionsResponse
+		toCheck  *toCheck
+	}{
+		{
+			name: "Test IP Add",
+			toAdd: models.GetDecisionsResponse{
+				{
+					Scope: ptr.Of("IP"),
+					Value: ptr.Of("192.168.1.1"),
+					Type:  ptr.Of("ban"),
+					ID:    1,
+				},
+			},
+			toCheck: &toCheck{
+				Value: "192.168.1.1",
+				Scope: "IP",
+				Type:  remediation.Ban,
+			},
+		},
+		{
+			name: "Test IP Delete",
+			toDelete: models.GetDecisionsResponse{
+				{
+					Scope: ptr.Of("IP"),
+					Value: ptr.Of("192.168.1.1"),
+					Type:  ptr.Of("ban"),
+					ID:    1,
+				},
+			},
+			toCheck: &toCheck{
+				Value: "192.168.1.1",
+				Scope: "IP",
+				Type:  remediation.Allow,
+			},
+		},
+		{
+			name: "Test Range Add",
+			toAdd: models.GetDecisionsResponse{
+				{
+					Scope: ptr.Of("Range"),
+					Value: ptr.Of("192.168.1.0/24"),
+					Type:  ptr.Of("ban"),
+					ID:    2,
+				},
+			},
+			toCheck: &toCheck{
+				Value: "192.168.1.24",
+				Scope: "IP",
+				Type:  remediation.Ban,
+			},
+		},
+		{
+			name: "Test Range Delete",
+			toDelete: models.GetDecisionsResponse{
+				{
+					Scope: ptr.Of("Range"),
+					Value: ptr.Of("192.168.1.0/24"),
+					Type:  ptr.Of("ban"),
+					ID:    2,
+				},
+			},
+			toCheck: &toCheck{
+				Value: "192.168.1.1",
+				Scope: "IP",
+				Type:  remediation.Allow,
+			},
+		},
+		{
+			name: "Test Country Add",
+			toAdd: models.GetDecisionsResponse{
+				{
+					Scope: ptr.Of("Country"),
+					Value: ptr.Of("FR"),
+					Type:  ptr.Of("ban"),
+					ID:    3,
+				},
+			},
+			toCheck: &toCheck{
+				Value: "FR",
+				Scope: "Country",
+				Type:  remediation.Ban,
+			},
+		},
+		{
+			name: "Test Country Delete",
+			toDelete: models.GetDecisionsResponse{
+				{
+					Scope: ptr.Of("Country"),
+					Value: ptr.Of("FR"),
+					Type:  ptr.Of("ban"),
+					ID:    3,
+				},
+			},
+			toCheck: &toCheck{
+				Value: "FR",
+				Scope: "Country",
+				Type:  remediation.Allow,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if len(tt.toAdd) > 0 {
+				dataSet.Add(tt.toAdd)
+				if tt.toCheck == nil {
+					t.Fatalf("toCheck is nil")
+				}
+				var r remediation.Remediation
+				var err error
+				switch tt.toCheck.Scope {
+				case "IP":
+					r, err = dataSet.CheckIP(tt.toCheck.Value)
+				case "Country":
+					r = dataSet.CheckCN(tt.toCheck.Value)
+				default:
+					t.Fatalf("unknown scope %s", tt.toCheck.Scope)
+				}
+				require.NoError(t, err)
+				assert.Equal(t, r, tt.toCheck.Type)
+			}
+			if len(tt.toDelete) > 0 {
+				dataSet.Remove(tt.toDelete)
+			}
+		})
+	}
+
+}

--- a/pkg/dataset/root_test.go
+++ b/pkg/dataset/root_test.go
@@ -1,6 +1,7 @@
 package dataset
 
 import (
+	"net/netip"
 	"testing"
 
 	"github.com/crowdsecurity/crowdsec-spoa/internal/remediation"
@@ -19,6 +20,19 @@ type toCheck struct {
 
 func TestDataSet(t *testing.T) {
 	dataSet := New()
+	t.Run("Test Init", func(t *testing.T) {
+		// Test new returns the types we expect
+		assert.NotNil(t, dataSet)
+		assert.IsType(t, &PrefixSet{}, dataSet.PrefixSet)
+		assert.IsType(t, &CNSet{}, dataSet.CNSet)
+		assert.IsType(t, &IPSet{}, dataSet.IPSet)
+		assert.NotNil(t, dataSet.PrefixSet)
+		assert.NotNil(t, dataSet.CNSet)
+		assert.NotNil(t, dataSet.IPSet)
+		assert.IsType(t, map[netip.Prefix]RemediationIdsMap{}, dataSet.PrefixSet.Items)
+		assert.IsType(t, map[string]RemediationIdsMap{}, dataSet.CNSet.Items)
+		assert.IsType(t, map[netip.Addr]RemediationIdsMap{}, dataSet.IPSet.Items)
+	})
 	tests := []struct {
 		name     string
 		toAdd    models.GetDecisionsResponse


### PR DESCRIPTION
Refactor dataset to use newer netip standard package comes with benefits:
- netip types are comparable so now everything can be stored within maps
- use a generic struct type to hold most add/remove logic since its the same across types
- only different is the types need to specify there own `Contains` function