### PR TITLE
fix: Update Docker configuration and paths

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG GOVERSION=1.22
+ARG GOVERSION=1.24
 
 FROM golang:${GOVERSION}-alpine AS build
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -33,10 +33,10 @@ services:
     image: haproxy:2.9.7-alpine
     volumes:
       - ./config/haproxy.cfg:/usr/local/etc/haproxy/haproxy.cfg
-      - ./config/crowdsec.cfg:/usr/local/etc/haproxy/crowdsec.cfg
+      - ./config/crowdsec.cfg:/etc/haproxy/crowdsec.cfg
       - sockets:/run/
       - templates:/var/lib/crowdsec/lua/haproxy/templates/
-      - lua:/usr/local/crowdsec/lua/haproxy/
+      - lua:/usr/lib/crowdsec-haproxy-spoa-bouncer/lua/
     ports:
       - "9090:9090"
     depends_on:
@@ -51,6 +51,7 @@ services:
     environment:
       - BOUNCER_KEY_SPOA=+4iYgItcalc9+0tWrvrj9R6Wded/W1IRwRtNmcWR9Ws
       - DISABLE_ONLINE_API=true
+      - CROWDSEC_BYPASS_DB_VOLUME_CHECK=true
     volumes:
       - geodb:/staging/var/lib/crowdsec/data/
     networks:


### PR DESCRIPTION
Split from #51 

- Upgrade Go version from 1.22 to 1.24 in Dockerfile for go.mod compatibility 
- Fix HAProxy config path: /usr/local/etc/haproxy/crowdsec.cfg -> /etc/haproxy/crowdsec.cfg (so we can keep haproxy.cfg for packages)
- Update Lua path to standard location: /usr/local/crowdsec/lua/haproxy/ -> /usr/lib/crowdsec-haproxy-spoa-bouncer/lua/ (so we can keep haproxy.cfg for package)
- Add CROWDSEC_BYPASS_DB_VOLUME_CHECK=true environment variable for CrowdSec container

Path corrections:
- Align with standard HAProxy Alpine container paths
- Use distribution-standard Lua library location
- Enable database volume check bypass for development