### PR TITLE
fix: Resolve maintidx CI issue by refactoring API constructor

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -240,7 +240,13 @@ func Execute() error {
 		return workerManager.Run(ctx)
 	})
 
-	apiServer := api.NewAPI(workerManager, HostManager, dataSet, &config.Geo, socketConnChan)
+	apiServer := api.NewAPI(api.APIConfig{
+		WorkerManager: workerManager,
+		HostManager:   HostManager,
+		Dataset:       dataSet,
+		GeoDatabase:   &config.Geo,
+		SocketChan:    socketConnChan,
+	})
 
 	for _, worker := range config.Workers {
 		workerManager.CreateChan <- worker

--- a/internal/api/root.go
+++ b/internal/api/root.go
@@ -86,6 +86,15 @@ type API struct {
 	ConnChan      chan server.SocketConn
 }
 
+// APIConfig holds the configuration for creating a new API instance
+type APIConfig struct {
+	WorkerManager *worker.Manager
+	HostManager   *host.Manager
+	Dataset       *dataset.DataSet
+	GeoDatabase   *geo.GeoDatabase
+	SocketChan    chan server.SocketConn
+}
+
 func (a *API) HandleCommand(command string, args []string, permission apiPermission.APIPermission) (interface{}, error) {
 	if handler, ok := a.Handlers[command]; ok {
 		return handler.handle(permission, args...)
@@ -93,13 +102,14 @@ func (a *API) HandleCommand(command string, args []string, permission apiPermiss
 	return nil, fmt.Errorf("command not found")
 }
 
-func NewAPI(WorkerManager *worker.Manager, HostManager *host.Manager, dataset *dataset.DataSet, geoDatabase *geo.GeoDatabase, socketChan chan server.SocketConn) *API {
+// NewAPI creates a new API instance and initializes it with the provided configuration
+func NewAPI(config APIConfig) *API {
 	a := &API{
-		WorkerManager: WorkerManager,
-		HostManager:   HostManager,
-		Dataset:       dataset,
-		GeoDatabase:   geoDatabase,
-		ConnChan:      socketChan,
+		WorkerManager: config.WorkerManager,
+		HostManager:   config.HostManager,
+		Dataset:       config.Dataset,
+		GeoDatabase:   config.GeoDatabase,
+		ConnChan:      config.SocketChan,
 	}
 
 	a.Handlers = map[string]APIHandler{


### PR DESCRIPTION
Merge before #51..#55

- Replace NewAPI function with 5 parameters with configuration struct pattern
- Add APIConfig struct to group related API dependencies
- Update NewAPI to accept single APIConfig parameter instead of multiple arguments
- Update cmd/root.go to use new APIConfig struct for initialization

Maintidx improvements:
- Reduces function parameter count from 5 to 1
- Improves code readability and maintainability
- Makes API configuration more explicit and structured
- Follows Go best practices for constructor patterns