### PR TITLE
fix: context propagation for graceful shutdown

### DIFF
--- a/internal/api/admin_handlers.go
+++ b/internal/api/admin_handlers.go
@@ -262,10 +262,10 @@ func (a *API) handleAdminConnection(ctx context.Context, sc server.SocketConn) {
 	reader := bufio.NewReader(sc.Conn)
 
 	for {
-		// Check if context is cancelled (shutdown signal)
+		// Check if context is canceled (shutdown signal)
 		select {
 		case <-ctx.Done():
-			log.Debug("Context cancelled, shutting down admin connection handler")
+			log.Debug("Context canceled, shutting down admin connection handler")
 			return
 		default:
 			// Continue with normal processing

--- a/internal/api/admin_handlers.go
+++ b/internal/api/admin_handlers.go
@@ -262,6 +262,15 @@ func (a *API) handleAdminConnection(ctx context.Context, sc server.SocketConn) {
 	reader := bufio.NewReader(sc.Conn)
 
 	for {
+		// Check if context is cancelled (shutdown signal)
+		select {
+		case <-ctx.Done():
+			log.Debug("Context cancelled, shutting down admin connection handler")
+			return
+		default:
+			// Continue with normal processing
+		}
+
 		// Read line by line instead of fixed buffer - more efficient for admin commands
 		line, err := reader.ReadString('\n')
 		if err != nil {

--- a/internal/api/admin_handlers.go
+++ b/internal/api/admin_handlers.go
@@ -271,61 +271,78 @@ func (a *API) handleAdminConnection(ctx context.Context, sc server.SocketConn) {
 			// Continue with normal processing
 		}
 
-		// Read line by line instead of fixed buffer - more efficient for admin commands
-		line, err := reader.ReadString('\n')
-		if err != nil {
-			if errors.Is(err, io.EOF) {
-				// Client closed the connection gracefully
-				break
-			}
-			log.Error("Read error:", err)
+		// Use a channel to make ReadString non-blocking with context cancellation
+		type readResult struct {
+			line string
+			err  error
+		}
+		
+		readChan := make(chan readResult, 1)
+		go func() {
+			line, err := reader.ReadString('\n')
+			readChan <- readResult{line: line, err: err}
+		}()
+		
+		select {
+		case <-ctx.Done():
+			log.Debug("Context cancelled during read, shutting down admin connection handler")
 			return
-		}
-
-		// Trim whitespace and skip empty lines
-		line = strings.TrimSpace(line)
-		if line == "" {
-			continue
-		}
-
-		apiCommand, args, err := a.parseAdminCommand(line)
-		if err != nil {
-			_, writeErr := fmt.Fprintf(sc.Conn, "ERROR [INVALID_REQUEST]: %s\n", err.Error())
-			if writeErr != nil {
-				log.Errorf("error writing parse error to admin socket: %v", writeErr)
+		case result := <-readChan:
+			if result.err != nil {
+				if errors.Is(result.err, io.EOF) {
+					// Client closed the connection gracefully
+					break
+				}
+				log.Error("Read error:", result.err)
+				return
 			}
-			continue
-		}
+			line := result.line
 
-		if len(apiCommand) == 0 {
-			_, writeErr := fmt.Fprintf(sc.Conn, "ERROR [INVALID_REQUEST]: Empty command\n")
-			if writeErr != nil {
-				log.Errorf("error writing empty command error to admin socket: %v", writeErr)
+			// Trim whitespace and skip empty lines
+			line = strings.TrimSpace(line)
+			if line == "" {
+				continue
 			}
-			continue
-		}
 
-		// Handle command directly without permission checks (admin-only connection)
-		response := a.handleAdminCommand(ctx, apiCommand, args)
-
-		if !response.Success {
-			log.WithFields(log.Fields{
-				"command":       strings.Join(apiCommand, ":"),
-				"args":          args,
-				"error_code":    response.Error.Code,
-				"error_message": response.Error.Message,
-			}).Debug("Admin command failed")
-
-			_, err := fmt.Fprintf(sc.Conn, "ERROR [%s]: %s\n", response.Error.Code, response.Error.Message)
+			apiCommand, args, err := a.parseAdminCommand(line)
 			if err != nil {
-				log.Errorf("error returning error to admin socket: %v", err)
+				_, writeErr := fmt.Fprintf(sc.Conn, "ERROR [INVALID_REQUEST]: %s\n", err.Error())
+				if writeErr != nil {
+					log.Errorf("error writing parse error to admin socket: %v", writeErr)
+				}
+				continue
 			}
-			continue
-		}
 
-		_, err = fmt.Fprintf(sc.Conn, "%v\n", response.Data)
-		if err != nil {
-			log.Errorf("error writing response to admin socket: %v", err)
+			if len(apiCommand) == 0 {
+				_, writeErr := fmt.Fprintf(sc.Conn, "ERROR [INVALID_REQUEST]: Empty command\n")
+				if writeErr != nil {
+					log.Errorf("error writing empty command error to admin socket: %v", writeErr)
+				}
+				continue
+			}
+
+			// Handle command directly without permission checks (admin-only connection)
+			response := a.handleAdminCommand(ctx, apiCommand, args)
+
+			if !response.Success {
+				log.WithFields(log.Fields{
+					"command":       strings.Join(apiCommand, ":"),
+					"args":          args,
+					"error_code":    response.Error.Code,
+					"error_message": response.Error.Message,
+				}).Debug("Admin command failed")
+
+				_, err := fmt.Fprintf(sc.Conn, "ERROR [%s]: %s\n", response.Error.Code, response.Error.Message)
+				if err != nil {
+					log.Errorf("error returning error to admin socket: %v", err)
+				}
+				continue
+			}
+
+			_, err = fmt.Fprintf(sc.Conn, "%v\n", response.Data)
+			if err != nil {
+				log.Errorf("error writing response to admin socket: %v", err)
+			}
 		}
 	}
 }

--- a/internal/api/worker_handlers.go
+++ b/internal/api/worker_handlers.go
@@ -54,14 +54,14 @@ func (a *API) handleWorkerConnectionEncoded(ctx context.Context, sc server.Socke
 			req messages.APIRequest
 			err error
 		}
-		
+
 		decodeChan := make(chan decodeResult, 1)
 		go func() {
 			var req messages.APIRequest
 			err := sc.Decoder.Decode(&req)
 			decodeChan <- decodeResult{req: req, err: err}
 		}()
-		
+
 		var req messages.APIRequest
 		select {
 		case <-ctx.Done():

--- a/internal/api/worker_handlers.go
+++ b/internal/api/worker_handlers.go
@@ -54,20 +54,19 @@ func (a *API) handleWorkerConnectionEncoded(ctx context.Context, sc server.Socke
 			req messages.APIRequest
 			err error
 		}
-		
+
 		decodeChan := make(chan decodeResult, 1)
 		go func() {
 			var req messages.APIRequest
 			err := sc.Decoder.Decode(&req)
 			decodeChan <- decodeResult{req: req, err: err}
 		}()
-		
+
 		var req messages.APIRequest
 		select {
 		case <-ctx.Done():
-			// Context cancelled - close connection to interrupt the decode goroutine
-			log.Debugf("Context cancelled during decode, closing connection for worker: %s", workerName)
-			sc.Conn.Close() // This will cause the decode goroutine to fail and exit
+			// Context cancelled - defer function will handle connection cleanup
+			log.Debugf("Context cancelled during decode, shutting down worker connection handler for worker: %s", workerName)
 			return
 		case result := <-decodeChan:
 			if result.err != nil {

--- a/internal/api/worker_handlers.go
+++ b/internal/api/worker_handlers.go
@@ -52,20 +52,20 @@ func (a *API) handleWorkerConnectionEncoded(ctx context.Context, sc server.Socke
 
 		// Set short read timeout to make decode responsive to context cancellation
 		sc.Conn.SetReadDeadline(time.Now().Add(10 * time.Millisecond))
-		
+
 		var req messages.APIRequest
 		err := sc.Decoder.Decode(&req)
-		
+
 		// Clear deadline immediately after decode attempt
 		sc.Conn.SetReadDeadline(time.Time{})
-		
+
 		if err != nil {
 			// Check if it's a timeout error
 			if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
 				// Timeout occurred - loop back to check context again
 				continue
 			}
-			
+
 			if errors.Is(err, io.EOF) {
 				// Client closed the connection gracefully
 				break

--- a/internal/api/worker_handlers.go
+++ b/internal/api/worker_handlers.go
@@ -61,7 +61,8 @@ func (a *API) handleWorkerConnectionEncoded(ctx context.Context, sc server.Socke
 
 		if err != nil {
 			// Check if it's a timeout error
-			if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
+			var netErr net.Error
+			if errors.As(err, &netErr) && netErr.Timeout() {
 				// Timeout occurred - loop back to check context again
 				continue
 			}

--- a/internal/api/worker_handlers.go
+++ b/internal/api/worker_handlers.go
@@ -40,6 +40,15 @@ func (a *API) handleWorkerConnectionEncoded(ctx context.Context, sc server.Socke
 	}()
 
 	for {
+		// Check if context is cancelled (shutdown signal)
+		select {
+		case <-ctx.Done():
+			log.Debugf("Context cancelled, shutting down worker connection handler for worker: %s", workerName)
+			return
+		default:
+			// Continue with normal processing
+		}
+
 		var req messages.APIRequest
 		if err := sc.Decoder.Decode(&req); err != nil {
 			if errors.Is(err, io.EOF) {


### PR DESCRIPTION
## **Add Context Propagation for Graceful Shutdown**

### **Problem**
Connection handlers had infinite loops with no context cancellation checks, preventing graceful shutdown when receiving SIGTERM/SIGINT signals.

### **How It Works**
1. **Context check** at start of each loop iteration for immediate shutdown response
2. **Connection timeout** (10ms) prevents blocking on I/O during shutdown  
3. **Timeout handling** loops back to check context again
4. **Defer cleanup** automatically closes connections and updates metrics

### **Benefits**
- **Graceful shutdown**: Handlers exit within 10ms of shutdown signal
- **No hanging processes**: All connection handlers terminate cleanly  
- **Efficient**: Minimal overhead for normal operations
- **Resource cleanup**: Proper connection and metrics cleanup via defer

### **Files Modified**
- `internal/api/worker_handlers.go` - Added context check + connection timeout
- `internal/api/admin_handlers.go` - Added simple context check