### PR TITLE
feat: implement HAProxy native redirects to replace Lua-based redirects

### DIFF
--- a/config/haproxy.cfg
+++ b/config/haproxy.cfg
@@ -35,9 +35,12 @@ frontend test
     ## Set a custom header on the request for upstream services to use
     http-request set-header X-CrowdSec-IsoCode %[var(txn.crowdsec.isocode)] if { var(txn.crowdsec.isocode) -m found }
 
-    ## Call lua script to handle the remediation (ban/captcha pages)
-    http-request lua.crowdsec_handle if { var(txn.crowdsec.remediation) -m found }
-    ## Note if the remediation is allow you should still call the handler incase a redirect is needed following a captcha
+    ## Handle 302 redirect for successful captcha validation (native HAProxy redirect)
+    http-request redirect code 302 location %[var(txn.crowdsec.redirect)] if { var(txn.crowdsec.remediation) -m str "allow" } { var(txn.crowdsec.redirect) -m found }
+    
+    ## Call lua script only for ban and captcha remediations (performance optimization)
+    http-request lua.crowdsec_handle if { var(txn.crowdsec.remediation) -m str "captcha" }
+    http-request lua.crowdsec_handle if { var(txn.crowdsec.remediation) -m str "ban" }
 
     ## Handle captcha cookie management via HAProxy (new approach)
     ## Set captcha cookie when SPOA provides captcha_status (pending or valid)

--- a/lua/crowdsec.lua
+++ b/lua/crowdsec.lua
@@ -113,14 +113,11 @@ function runtime.Handle(txn)
     reply:add_header("cache-control", "no-cache")
     reply:add_header("cache-control", "no-store")
 
+    -- NOTE: "allow" remediation with redirects is now handled natively by HAProxy
+    -- This Lua handler is only called for "captcha" and "ban" remediations
     if remediation == "allow" then
-        local redirect_uri = get_txn_var(txn, "crowdsec.redirect")
-        if redirect_uri ~= "" then
-            reply:set_status(302)
-            reply:add_header("Location", redirect_uri)
-        else
-            return
-        end
+        runtime.logger.warning("Lua handler called for 'allow' remediation - this should not happen with native redirects")
+        return
     end
 
     if remediation == "captcha" then


### PR DESCRIPTION
- Replace Lua redirect handling with native HAProxy 302 redirects
- Optimize performance by calling Lua only for ban/captcha remediations
- Remove redirect logic from crowdsec.lua, keeping only page rendering
- Add conditional HAProxy rules to handle redirects natively
- Improve response times for normal 'allow' traffic by avoiding Lua overhead

This change maintains full functionality while significantly improving performance for post-captcha redirects and normal allowed traffic.

just for some stats:

before: mean request time was 2.6ms on average

after: mean request time was 0.02ms on average

this is simply because we are not invoking the lua engine for every request anymore. (this was the main aim of moving the cookie setting and this out of lua code)