### PR TITLE
fix: correct service name in Debian packaging scripts

### DIFF
--- a/debian/postrm
+++ b/debian/postrm
@@ -2,8 +2,8 @@
 
 set -eu
 
-BOUNCER="crowdsec-haproxy-spoa-bouncer"
-CONFIG="/etc/crowdsec/bouncers/$BOUNCER.yaml"
+#shellcheck source=./scripts/_bouncer.sh
+. "/usr/lib/$DPKG_MAINTSCRIPT_PACKAGE/_bouncer.sh"
 
 if [ "$1" = "purge" ]; then
     if [ -f "$CONFIG.id" ]; then

--- a/debian/prerm
+++ b/debian/prerm
@@ -2,10 +2,11 @@
 
 set -eu
 
-BOUNCER="crowdsec-haproxy-spoa-bouncer"
+#shellcheck source=./scripts/_bouncer.sh
+. "/usr/lib/$DPKG_MAINTSCRIPT_PACKAGE/_bouncer.sh"
 
-systemctl stop "$BOUNCER" || echo "cannot stop service"
-systemctl disable "$BOUNCER" || echo "cannot disable service"
+systemctl stop "$SERVICE" || echo "cannot stop service"
+systemctl disable "$SERVICE" || echo "cannot disable service"
 
 cmp /etc/haproxy/crowdsec.cfg /usr/share/doc/crowdsec-haproxy-spoa-bouncer/examples/crowdsec.cfg &&
     rm -f /etc/haproxy/crowdsec.cfg || echo "not removing /etc/haproxy/crowdsec.cfg, it has been modified"


### PR DESCRIPTION
fix #64 

- Fix debian/prerm to use correct service name from _bouncer.sh
- Fix debian/postrm to source _bouncer.sh for consistency
- Resolves service stop/disable failures during package upgrades
- Service name now correctly resolves to 'crowdsec-spoa-bouncer.service'
- Aligns Debian packaging with already-correct RPM implementation