### PR TITLE
fix: remove stale unix socket files before creating listeners

### DIFF
--- a/pkg/server/root.go
+++ b/pkg/server/root.go
@@ -166,6 +166,14 @@ func (s *Server) NewWorkerListener(name string, gid int) (string, error) {
 }
 
 func newUnixSocket(path string) (net.Listener, error) {
+	// Remove stale socket file if it exists
+	// This handles cases where the server crashed and left the socket file behind
+	if _, err := os.Stat(path); err == nil {
+		if err := os.Remove(path); err != nil {
+			return nil, fmt.Errorf("failed to remove stale socket file %s: %w", path, err)
+		}
+	}
+
 	l, err := net.Listen("unix", path)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
- Add cleanup of stale socket files in newUnixSocket function
- Handles cases where server crashes and leaves socket files on disk
- Prevents 'address already in use' errors on restart
- Applies to both admin and worker socket listeners
- Uses os.Stat to check if file exists before removal

Whilst testing, the admin socket was causing issue when the socket was remaining on disk.