### PR TITLE
Implement version flag functionality

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -70,7 +70,7 @@ func Execute() error {
 
 	// Handle version flags
 	if *bouncerVersion {
-		fmt.Printf("%s %s\n", name, version.String())
+		fmt.Fprint(os.Stdout, version.FullString())
 		return nil
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -58,7 +58,7 @@ func Execute() error {
 	// Parent pflags
 	configPath := pflag.StringP("config", "c", "/etc/crowdsec/bouncer/crowdsec-spoa-bouncer.yaml", "path to crowdsec-spoa-bouncer.yaml")
 	verbose := pflag.BoolP("verbose", "v", false, "set verbose mode")
-	bouncerVersion := pflag.Bool("V", false, "display version and exit (deprecated)")
+	bouncerVersion := pflag.BoolP("V", "V", false, "display version and exit (deprecated)")
 	pflag.BoolVar(bouncerVersion, "version", *bouncerVersion, "display version and exit")
 	testConfig := pflag.BoolP("test", "t", false, "test config and exit")
 	showConfig := pflag.BoolP("show-config", "T", false, "show full config (.yaml + .yaml.local) and exit")
@@ -67,6 +67,13 @@ func Execute() error {
 	workerConfigJSON := pflag.String("worker-config", "", "worker configuration as JSON string")
 
 	pflag.Parse()
+
+	// Handle version flags
+	if *bouncerVersion {
+		fmt.Printf("%s %s\n", name, version.String())
+		return nil
+	}
+
 	if *workerConfigJSON != "" {
 		var w *worker.Worker
 		if err := json.Unmarshal([]byte(*workerConfigJSON), &w); err != nil {


### PR DESCRIPTION
fix #76 

- Add handling for --version and -V flags to display version information
- Fix -V flag to work as short flag (was incorrectly defined as long flag)
- Version information is populated at build time via ldflags in Makefile
- Both flags now output: 'crowdsec-spoa-bouncer v0.1.0-rc2-a188184e7f54a0b7a5f38133cfdbec8c93633817'
- Version data includes git tag, commit hash, and build timestamp