### PR TITLE
Fix default config path from /etc/crowdsec/bouncer/ to /etc/crowdsec/…

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -56,7 +56,7 @@ func HandleSignals(ctx context.Context) error {
 
 func Execute() error {
 	// Parent pflags
-	configPath := pflag.StringP("config", "c", "/etc/crowdsec/bouncer/crowdsec-spoa-bouncer.yaml", "path to crowdsec-spoa-bouncer.yaml")
+	configPath := pflag.StringP("config", "c", "/etc/crowdsec/bouncers/crowdsec-spoa-bouncer.yaml", "path to crowdsec-spoa-bouncer.yaml")
 	verbose := pflag.BoolP("verbose", "v", false, "set verbose mode")
 	bouncerVersion := pflag.Bool("V", false, "display version and exit (deprecated)")
 	pflag.BoolVar(bouncerVersion, "version", *bouncerVersion, "display version and exit")


### PR DESCRIPTION
…bouncers/

fix #75 

- Change default config path in cmd/root.go from '/etc/crowdsec/bouncer/' to '/etc/crowdsec/bouncers/'
- This aligns with the standard CrowdSec bouncer directory structure
- All other files (debian, rpm, docker, scripts) already use the correct '/bouncers/' path
- Fixes inconsistency where only the default flag value was using the old path